### PR TITLE
Dynamic changes

### DIFF
--- a/.github/workflows/update-stats.yml
+++ b/.github/workflows/update-stats.yml
@@ -1,0 +1,32 @@
+name: Update org stats
+
+on:
+  schedule:
+    - cron: '0 3 * * *'   # runs daily at 03:00 UTC
+  workflow_dispatch:        # allows manual runs from the Actions tab
+
+permissions:
+  contents: write
+
+jobs:
+  update-stats:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run stats script
+        run: node scripts/update-stats.mjs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Commit stats.json if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add stats.json
+          git diff --staged --quiet || git commit -m "chore: update org stats"
+          git push

--- a/scripts/update-stats.mjs
+++ b/scripts/update-stats.mjs
@@ -9,7 +9,7 @@ const org = 'peviitor-ro';
 const token = process.env.GITHUB_TOKEN;
 
 if (!token) {
-  console.error('Lipsește GITHUB_TOKEN din variabilele de mediu.');
+  console.error('Missing GITHUB_TOKEN environment variable.');
   process.exit(1);
 }
 
@@ -59,7 +59,6 @@ const runQuery = async (variables, attempt = 1) => {
   if (!res.ok) {
     if ((res.status === 502 || res.status === 504) && attempt < 4) {
       const waitMs = attempt * 2000;
-      console.warn(`  GitHub a raspuns cu ${res.status}, reincerc in ${waitMs}ms (incercarea ${attempt + 1})...`);
       await sleep(waitMs);
       return runQuery(variables, attempt + 1);
     }
@@ -76,7 +75,6 @@ const runQuery = async (variables, attempt = 1) => {
 };
 
 async function main() {
-  console.log(`Se preiau repo-urile publice + contribuitori pentru ${org}...`);
 
   let hasNextPage = true;
   let cursor = null;
@@ -99,7 +97,6 @@ async function main() {
 
     hasNextPage = repos.pageInfo.hasNextPage;
     cursor = repos.pageInfo.endCursor;
-    console.log(`  ... ${totalRepos} repo-uri procesate pana acum`);
   }
 
   const stats = {
@@ -109,10 +106,10 @@ async function main() {
   };
 
   writeFileSync('stats.json', JSON.stringify(stats, null, 2));
-  console.log('Salvat stats.json:', stats);
+  console.log('Saved stats.json:', stats);
 }
 
 main().catch((error) => {
-  console.error('Eroare fatala:', error);
+  console.error('Fatal error:', error);
   process.exit(1);
 });

--- a/scripts/update-stats.mjs
+++ b/scripts/update-stats.mjs
@@ -1,0 +1,118 @@
+// scripts/update-stats.mjs
+// Runs in GitHub Actions (with a token), NOT in the browser.
+// Uses the GitHub GraphQL API to fetch public repos and their contributors
+// in a small number of paginated requests, then saves the result to stats.json.
+
+import { writeFileSync } from 'fs';
+
+const org = 'peviitor-ro';
+const token = process.env.GITHUB_TOKEN;
+
+if (!token) {
+  console.error('Lipsește GITHUB_TOKEN din variabilele de mediu.');
+  process.exit(1);
+}
+
+const query = `
+  query ($org: String!, $reposCursor: String) {
+    organization(login: $org) {
+      repositories(first: 10, privacy: PUBLIC, after: $reposCursor) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          name
+          defaultBranchRef {
+            target {
+              ... on Commit {
+                history(first: 100) {
+                  nodes {
+                    author {
+                      user {
+                        login
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const runQuery = async (variables, attempt = 1) => {
+  const res = await fetch('https://api.github.com/graphql', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+
+  if (!res.ok) {
+    if ((res.status === 502 || res.status === 504) && attempt < 4) {
+      const waitMs = attempt * 2000;
+      console.warn(`  GitHub a raspuns cu ${res.status}, reincerc in ${waitMs}ms (incercarea ${attempt + 1})...`);
+      await sleep(waitMs);
+      return runQuery(variables, attempt + 1);
+    }
+    throw new Error(`GraphQL request failed: ${res.status}`);
+  }
+
+  const json = await res.json();
+
+  if (json.errors) {
+    throw new Error(`GraphQL errors: ${JSON.stringify(json.errors)}`);
+  }
+
+  return json.data;
+};
+
+async function main() {
+  console.log(`Se preiau repo-urile publice + contribuitori pentru ${org}...`);
+
+  let hasNextPage = true;
+  let cursor = null;
+  let totalRepos = 0;
+  const volunteers = new Set();
+
+  while (hasNextPage) {
+    const data = await runQuery({ org, reposCursor: cursor });
+    const repos = data.organization.repositories;
+
+    totalRepos += repos.nodes.length;
+
+    for (const repo of repos.nodes) {
+      const commits = repo.defaultBranchRef?.target?.history?.nodes ?? [];
+      for (const commit of commits) {
+        const login = commit.author?.user?.login;
+        if (login) volunteers.add(login);
+      }
+    }
+
+    hasNextPage = repos.pageInfo.hasNextPage;
+    cursor = repos.pageInfo.endCursor;
+    console.log(`  ... ${totalRepos} repo-uri procesate pana acum`);
+  }
+
+  const stats = {
+    projects: totalRepos,
+    volunteers: volunteers.size,
+    updatedAt: new Date().toISOString(),
+  };
+
+  writeFileSync('stats.json', JSON.stringify(stats, null, 2));
+  console.log('Salvat stats.json:', stats);
+}
+
+main().catch((error) => {
+  console.error('Eroare fatala:', error);
+  process.exit(1);
+});

--- a/src/dist/main.css
+++ b/src/dist/main.css
@@ -3236,94 +3236,94 @@ p {
   margin-bottom: 0;
 }
 .main-stories .stories-section .swiper-slide:nth-child(1) .story-slide__card {
-  background: linear-gradient(135deg, #facb6b, #9fc1bf);
+  background: linear-gradient(135deg, #f4b3d6, #e685b9);
 }
 .main-stories .stories-section .swiper-slide:nth-child(2) .story-slide__card {
-  background: linear-gradient(315deg, #9fc1bf, #f7f7f7);
+  background: linear-gradient(225deg, #9ebac5, #e685b9);
 }
 .main-stories .stories-section .swiper-slide:nth-child(3) .story-slide__card {
-  background: linear-gradient(180deg, #9fc1bf, #f4b3d6);
+  background: linear-gradient(90deg, #f7f7f7, #979db4);
 }
 .main-stories .stories-section .swiper-slide:nth-child(4) .story-slide__card {
-  background: linear-gradient(90deg, #979db4, #f7f7f7);
-}
-.main-stories .stories-section .swiper-slide:nth-child(5) .story-slide__card {
-  background: linear-gradient(180deg, #fadceb, #9fc1bf);
-}
-.main-stories .stories-section .swiper-slide:nth-child(6) .story-slide__card {
-  background: linear-gradient(0deg, #facb6b, #fadceb);
-}
-.main-stories .stories-section .swiper-slide:nth-child(7) .story-slide__card {
-  background: linear-gradient(225deg, #f7f7f7, #e685b9);
-}
-.main-stories .stories-section .swiper-slide:nth-child(8) .story-slide__card {
-  background: linear-gradient(90deg, #f7f7f7, #fadceb);
-}
-.main-stories .stories-section .swiper-slide:nth-child(9) .story-slide__card {
-  background: linear-gradient(270deg, #979db4, #fadceb);
-}
-.main-stories .stories-section .swiper-slide:nth-child(10) .story-slide__card {
-  background: linear-gradient(270deg, #9fc1bf, #facb6b);
-}
-.main-stories .stories-section .swiper-slide:nth-child(11) .story-slide__card {
-  background: linear-gradient(270deg, #f4f4f4, #e685b9);
-}
-.main-stories .stories-section .swiper-slide:nth-child(12) .story-slide__card {
-  background: linear-gradient(270deg, #9ebac5, #9fc1bf);
-}
-.main-stories .stories-section .swiper-slide:nth-child(13) .story-slide__card {
-  background: linear-gradient(45deg, #f7f7f7, #f4f4f4);
-}
-.main-stories .stories-section .swiper-slide:nth-child(14) .story-slide__card {
-  background: linear-gradient(270deg, #979db4, #facb6b);
-}
-.main-stories .stories-section .swiper-slide:nth-child(15) .story-slide__card {
-  background: linear-gradient(225deg, #e685b9, #979db4);
-}
-.main-stories .stories-section .swiper-slide:nth-child(16) .story-slide__card {
   background: linear-gradient(90deg, #9fc1bf, #f7f7f7);
 }
+.main-stories .stories-section .swiper-slide:nth-child(5) .story-slide__card {
+  background: linear-gradient(270deg, #9ebac5, #f7f7f7);
+}
+.main-stories .stories-section .swiper-slide:nth-child(6) .story-slide__card {
+  background: linear-gradient(90deg, #9ebac5, #979db4);
+}
+.main-stories .stories-section .swiper-slide:nth-child(7) .story-slide__card {
+  background: linear-gradient(45deg, #f4f4f4, #facb6b);
+}
+.main-stories .stories-section .swiper-slide:nth-child(8) .story-slide__card {
+  background: linear-gradient(45deg, #facb6b, #9fc1bf);
+}
+.main-stories .stories-section .swiper-slide:nth-child(9) .story-slide__card {
+  background: linear-gradient(90deg, #f4f4f4, #facb6b);
+}
+.main-stories .stories-section .swiper-slide:nth-child(10) .story-slide__card {
+  background: linear-gradient(90deg, #9fc1bf, #facb6b);
+}
+.main-stories .stories-section .swiper-slide:nth-child(11) .story-slide__card {
+  background: linear-gradient(90deg, #fadceb, #f7f7f7);
+}
+.main-stories .stories-section .swiper-slide:nth-child(12) .story-slide__card {
+  background: linear-gradient(45deg, #f7f7f7, #facb6b);
+}
+.main-stories .stories-section .swiper-slide:nth-child(13) .story-slide__card {
+  background: linear-gradient(180deg, #979db4, #9ebac5);
+}
+.main-stories .stories-section .swiper-slide:nth-child(14) .story-slide__card {
+  background: linear-gradient(0deg, #facb6b, #f4f4f4);
+}
+.main-stories .stories-section .swiper-slide:nth-child(15) .story-slide__card {
+  background: linear-gradient(0deg, #f7f7f7, #fadceb);
+}
+.main-stories .stories-section .swiper-slide:nth-child(16) .story-slide__card {
+  background: linear-gradient(315deg, #9ebac5, #9fc1bf);
+}
 .main-stories .stories-section .swiper-slide:nth-child(17) .story-slide__card {
-  background: linear-gradient(0deg, #9ebac5, #f4b3d6);
+  background: linear-gradient(315deg, #fadceb, #e685b9);
 }
 .main-stories .stories-section .swiper-slide:nth-child(18) .story-slide__card {
-  background: linear-gradient(45deg, #f7f7f7, #e685b9);
+  background: linear-gradient(225deg, #f4b3d6, #f7f7f7);
 }
 .main-stories .stories-section .swiper-slide:nth-child(19) .story-slide__card {
-  background: linear-gradient(315deg, #9fc1bf, #fadceb);
+  background: linear-gradient(180deg, #f4b3d6, #e685b9);
 }
 .main-stories .stories-section .swiper-slide:nth-child(20) .story-slide__card {
-  background: linear-gradient(45deg, #facb6b, #f4f4f4);
+  background: linear-gradient(225deg, #facb6b, #9ebac5);
 }
 .main-stories .stories-section .swiper-slide:nth-child(21) .story-slide__card {
-  background: linear-gradient(45deg, #f4f4f4, #f7f7f7);
+  background: linear-gradient(45deg, #979db4, #f4b3d6);
 }
 .main-stories .stories-section .swiper-slide:nth-child(22) .story-slide__card {
-  background: linear-gradient(180deg, #979db4, #fadceb);
+  background: linear-gradient(270deg, #f4f4f4, #9fc1bf);
 }
 .main-stories .stories-section .swiper-slide:nth-child(23) .story-slide__card {
-  background: linear-gradient(225deg, #f4b3d6, #9fc1bf);
+  background: linear-gradient(135deg, #facb6b, #f7f7f7);
 }
 .main-stories .stories-section .swiper-slide:nth-child(24) .story-slide__card {
-  background: linear-gradient(225deg, #f4b3d6, #9ebac5);
+  background: linear-gradient(90deg, #e685b9, #f4f4f4);
 }
 .main-stories .stories-section .swiper-slide:nth-child(25) .story-slide__card {
-  background: linear-gradient(45deg, #9ebac5, #9fc1bf);
+  background: linear-gradient(180deg, #9ebac5, #979db4);
 }
 .main-stories .stories-section .swiper-slide:nth-child(26) .story-slide__card {
-  background: linear-gradient(135deg, #f7f7f7, #facb6b);
+  background: linear-gradient(45deg, #f4f4f4, #979db4);
 }
 .main-stories .stories-section .swiper-slide:nth-child(27) .story-slide__card {
-  background: linear-gradient(0deg, #9fc1bf, #f7f7f7);
+  background: linear-gradient(180deg, #979db4, #fadceb);
 }
 .main-stories .stories-section .swiper-slide:nth-child(28) .story-slide__card {
-  background: linear-gradient(270deg, #e685b9, #facb6b);
+  background: linear-gradient(0deg, #9ebac5, #f4f4f4);
 }
 .main-stories .stories-section .swiper-slide:nth-child(29) .story-slide__card {
-  background: linear-gradient(90deg, #fadceb, #979db4);
+  background: linear-gradient(45deg, #f7f7f7, #fadceb);
 }
 .main-stories .stories-section .swiper-slide:nth-child(30) .story-slide__card {
-  background: linear-gradient(90deg, #f4b3d6, #9ebac5);
+  background: linear-gradient(90deg, #9fc1bf, #9ebac5);
 }
 .main-stories .stories-section .stories-nav {
   background-color: #ffffff;

--- a/src/js/mission.js
+++ b/src/js/mission.js
@@ -1,23 +1,57 @@
 const totalJobs = document.querySelector('#total-jobs');
-const url = 'https://api.peviitor.ro/v1/total/';
+const totalVolunteers = document.querySelector('#total-volunteers');
+const totalProjects = document.querySelector('#total-projects');
+
+const jobsUrl = 'https://api.peviitor.ro/v1/total/';
+const org = 'peviitor-ro';
+const headers = { Accept: 'application/vnd.github+json' };
+const CACHE_KEY = 'peviitor_github_stats';
+const CACHE_TTL_MS = 6 * 60 * 60 * 1000;
+
+const getCache = () => {
+  const raw = JSON.parse(localStorage.getItem(CACHE_KEY) || 'null');
+  return raw && Date.now() - raw.timestamp < CACHE_TTL_MS ? raw : null;
+};
+
+const computeGithubStats = async () => {
+  const reposRes = await fetch(`https://api.github.com/orgs/${org}/repos?per_page=100&type=public`, { headers });
+  const repos = await reposRes.json();
+
+  const volunteers = new Set();
+  for (const repo of repos) {
+    const res = await fetch(`https://api.github.com/repos/${repo.full_name}/contributors?per_page=100`, { headers });
+    if (res.ok) {
+      (await res.json()).forEach((c) => c.type !== 'Bot' && volunteers.add(c.login));
+    }
+  }
+
+  return { projects: repos.length, volunteers: volunteers.size };
+};
 
 document.addEventListener('DOMContentLoaded', async () => {
   try {
-    const response = await fetch(url);
-
-    if (!response.ok) {
-      throw new Error('Network response was not ok');
-    }
-
-    const data = await response.json();
-
-    if (data?.total?.jobs) {
-      totalJobs.textContent = data.total.jobs.toLocaleString('de-DE');
-    } else {
-      totalJobs.textContent = '15.000';
-    }
-  } catch (error) {
-    console.error('Fetch error:', error);
+    const res = await fetch(jobsUrl);
+    const data = await res.json();
+    totalJobs.textContent = data?.total?.jobs?.toLocaleString('de-DE') ?? '15.000';
+  } catch {
     totalJobs.textContent = '15.000';
   }
-});
+
+  const cached = getCache();
+  if (cached) {
+    totalProjects.textContent = cached.projects.toLocaleString('de-DE');
+    totalVolunteers.textContent = cached.volunteers.toLocaleString('de-DE');
+    return;
+  }
+
+  try {
+    const { projects, volunteers } = await computeGithubStats();
+    totalProjects.textContent = projects.toLocaleString('de-DE');
+    totalVolunteers.textContent = volunteers.toLocaleString('de-DE');
+    localStorage.setItem(CACHE_KEY, JSON.stringify({ projects, volunteers, timestamp: Date.now() }));
+  } catch (error) {
+    console.error('GitHub stats fetch error:', error);
+    totalProjects.textContent = '60';
+    totalVolunteers.textContent = '300';
+  }
+}); //test updated

--- a/src/js/mission.js
+++ b/src/js/mission.js
@@ -3,55 +3,27 @@ const totalVolunteers = document.querySelector('#total-volunteers');
 const totalProjects = document.querySelector('#total-projects');
 
 const jobsUrl = 'https://api.peviitor.ro/v1/total/';
-const org = 'peviitor-ro';
-const headers = { Accept: 'application/vnd.github+json' };
-const CACHE_KEY = 'peviitor_github_stats';
-const CACHE_TTL_MS = 6 * 60 * 60 * 1000;
-
-const getCache = () => {
-  const raw = JSON.parse(localStorage.getItem(CACHE_KEY) || 'null');
-  return raw && Date.now() - raw.timestamp < CACHE_TTL_MS ? raw : null;
-};
-
-const computeGithubStats = async () => {
-  const reposRes = await fetch(`https://api.github.com/orgs/${org}/repos?per_page=100&type=public`, { headers });
-  const repos = await reposRes.json();
-
-  const volunteers = new Set();
-  for (const repo of repos) {
-    const res = await fetch(`https://api.github.com/repos/${repo.full_name}/contributors?per_page=100`, { headers });
-    if (res.ok) {
-      (await res.json()).forEach((c) => c.type !== 'Bot' && volunteers.add(c.login));
-    }
-  }
-
-  return { projects: repos.length, volunteers: volunteers.size };
-};
+const statsUrl = 'https://raw.githubusercontent.com/danipop-hp/oportunitatisicariere_web/modificare/stats.json';
 
 document.addEventListener('DOMContentLoaded', async () => {
   try {
     const res = await fetch(jobsUrl);
     const data = await res.json();
     totalJobs.textContent = data?.total?.jobs?.toLocaleString('de-DE') ?? '15.000';
-  } catch {
+  } catch (error) {
+    console.error('Jobs fetch error:', error);
     totalJobs.textContent = '15.000';
   }
 
-  const cached = getCache();
-  if (cached) {
-    totalProjects.textContent = cached.projects.toLocaleString('de-DE');
-    totalVolunteers.textContent = cached.volunteers.toLocaleString('de-DE');
-    return;
-  }
-
   try {
-    const { projects, volunteers } = await computeGithubStats();
-    totalProjects.textContent = projects.toLocaleString('de-DE');
-    totalVolunteers.textContent = volunteers.toLocaleString('de-DE');
-    localStorage.setItem(CACHE_KEY, JSON.stringify({ projects, volunteers, timestamp: Date.now() }));
+    const res = await fetch(statsUrl);
+    if (!res.ok) throw new Error(`Stats fetch failed: ${res.status}`);
+    const stats = await res.json();
+    totalProjects.textContent = stats.projects.toLocaleString('de-DE');
+    totalVolunteers.textContent = stats.volunteers.toLocaleString('de-DE');
   } catch (error) {
-    console.error('GitHub stats fetch error:', error);
-    totalProjects.textContent = '60';
-    totalVolunteers.textContent = '300';
+    console.error('Stats fetch error:', error);
+    totalProjects.textContent = '60+';
+    totalVolunteers.textContent = '300+';
   }
-}); //test updated
+});

--- a/src/misiunea-noastra.html
+++ b/src/misiunea-noastra.html
@@ -328,14 +328,14 @@
                 <div class="value-icon">
                   <i class="ri-team-line"></i>
                 </div>
-                <h3>300+</h3>
+                <h3 id="total-volunteers"></h3>
                 <p>Voluntari</p>
               </div>
               <div class="value-card">
                 <div class="value-icon">
                   <i class="ri-github-fill"></i>
                 </div>
-                <h3>60+</h3>
+                <h3 id="total-projects"></h3>
                 <p>Proiecte</p>
               </div>
             </div>

--- a/stats.json
+++ b/stats.json
@@ -1,0 +1,5 @@
+{
+  "projects": 81,
+  "volunteers": 105,
+  "updatedAt": "2026-07-21T09:53:11.560Z"
+}


### PR DESCRIPTION
Voluntarii/proiectele apar puțin mai târziu decât locurile de muncă, pentru că vin din GitHub, nu din API-ul vostru. Practic, ca să aflu câți voluntari unici sunt, trebuie să întreb GitHub despre fiecare din cele 81 de repo-uri în parte (cine a contribuit la fiecare), deci ~82 de cereri odată. Iar GitHub permite doar 60 de cereri pe oră fără cont, deci dacă intru prea des sau vin mai mulți vizitatori repede unul după altul, se poate bloca temporar și apar valorile vechi (fallback) în loc de cele reale. Am pus un cache de 6 ore ca să reduc riscul, dar nu-l elimină complet. 



